### PR TITLE
disable PAM in sshd config

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -9,7 +9,8 @@ RUN mkdir /var/run/sshd \
     && echo 'root:resin' | chpasswd \
     && sed -i 's/PermitRootLogin without-password/PermitRootLogin yes/' /etc/ssh/sshd_config \
     # SSH login fix. Otherwise user is kicked off after login
-    && sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
+    && sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd \
+    && RUN sed -i 's/UsePAM yes/UsePAM no/' /etc/ssh/sshd_config
 
 ENV INITSYSTEM on
 COPY start.sh /start.sh


### PR DESCRIPTION
This disables PAM module in the sshd configuration, which is what seemed to be the issue which causes edison and other 3.10 based boards to fail when trying to ssh into them
