### PR TITLE
remove python as a dependency

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,7 +1,7 @@
 # This first line selects our base image. In this instance we use the dockerfile templates,
 # this means the appropriate image gets picked for instance on rpi3, this would end up
 # resolving to resin/raspberrypi3-python:latest
-FROM resin/%%RESIN_MACHINE_NAME%%-python
+FROM resin/%%RESIN_MACHINE_NAME%%-debian
 MAINTAINER Shaun Mulligan <shaun@resin.io>
 
 # here we install apt dependencies. We also remove the apt lists in the same step,

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,0 @@
-from time import sleep
-print "hello from python..."
-
-while 1:
-    print 'waiting'
-    sleep(60)

--- a/src/start.sh
+++ b/src/start.sh
@@ -5,4 +5,8 @@ if [ "$INITSYSTEM" != "on" ]; then
   /usr/sbin/sshd -p 22 &
 fi
 
-python src/main.py
+echo "This is where your application would start..."
+while : ; do
+  echo "waiting"
+  sleep 60
+done


### PR DESCRIPTION
This brings down the container size from ~500MB to ~170MB (tested on RPi3), which results in download size decrease from ~200MB to ~70MB. It should be quicker to deploy, and Python does not add much to the example.
